### PR TITLE
fix: Only place ore where there is already rock.

### DIFF
--- a/src/main/java/org/terasology/oreGeneration/generation/OreRasterizer.java
+++ b/src/main/java/org/terasology/oreGeneration/generation/OreRasterizer.java
@@ -49,7 +49,10 @@ public class OreRasterizer implements WorldRasterizer, WorldRasterizerPlugin {
             Map<StructureNodeType, Block> nodeTypeToBlocks = Maps.newHashMap();
             for (Vector3i position : ChunkConstants.CHUNK_REGION) {
                 StructureNodeType nodeType = oreFacet.get(oreGenCreator, position);
-                if (nodeType != null && oreGenCreator.canReplaceBlock(chunk.chunkToWorldPosition(position), chunkRegion)) {
+                if (nodeType != null
+                    && oreGenCreator.canReplaceBlock(chunk.chunkToWorldPosition(position), chunkRegion)
+                    && chunk.getBlock(position).getBlockFamily().hasCategory("rock")
+                ) {
                     if (!nodeTypeToBlocks.containsKey(nodeType)) {
                         nodeTypeToBlocks.put(nodeType, oreGenCreator.getReplacementBlock(nodeType));
                     }


### PR DESCRIPTION
This fixes both the ores generated floating inside volcanoes, and the ores generated floating in caves after https://github.com/Terasology/Caves/pull/10. It also means that ores no longer occur in soil or sand, which looked weird anyway. Any block with the "rock" category (which includes the usual CoreAssets:Stone, but may include other types of stone too) is possible to replace with ores. The pre-existing filters (based on the DensityFacet) still apply too.